### PR TITLE
Add error codes and JavaScript error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,3 +23,7 @@ var runner = spawn(electron, [__dirname + '/run.js'], {cwd: process.cwd()})
 runner.stdout.pipe(process.stdout)
 runner.stderr.pipe(process.stderr)
 process.stdin.pipe(runner.stdin)
+
+runner.on('close', function (code) {
+  process.exit(code)
+})


### PR DESCRIPTION
I'm trying to add this to Travis CI, which requires valid error exit codes when exiting the application. Also the tests hang whenever there is any kind of JavaScript error, so I added some handling for that as well. They should now send an error exit code of 1 when there is a JavaScript error.
